### PR TITLE
Turn ModelWithEffect into a typed tuple

### DIFF
--- a/examples/LoginForm/App.js
+++ b/examples/LoginForm/App.js
@@ -11,7 +11,7 @@ function init() {
     apiUser: null
   };
 
-  return { model, effect: Effect.empty() };
+  return [model, Effect.empty()];
 }
 
 // -- UPDATE
@@ -35,32 +35,26 @@ function LoginFormMsg(msg) {
 function update(msg, model) {
   switch (msg.tag) {
     case "Login":
-      return {
-        model,
-        effect: login(model.loginForm.email, model.loginForm.password)
-      };
+      return [model, login(model.loginForm.email, model.loginForm.password)];
 
     case "LoginRequestSuccess":
-      return {
-        model: assoc("apiUser", msg.response, model),
-        effect: Effect.empty()
-      };
+      return [assoc("apiUser", msg.response, model), Effect.empty()];
 
     case "LoginRequestFailure":
-      return { model, effect: Effect.empty() };
+      return [model, Effect.empty()];
 
     case "LoginFormMsg":
-      return {
-        model: assoc(
+      return [
+        assoc(
           "loginForm",
           LoginForm.update(msg.msg, model.loginForm).model,
           model
         ),
-        effect: Effect.empty()
-      };
+        Effect.empty()
+      ];
 
     default:
-      return { model, effect: Effect.empty() };
+      return [model, Effect.empty()];
   }
 }
 

--- a/examples/LoginForm/LoginForm.js
+++ b/examples/LoginForm/LoginForm.js
@@ -21,20 +21,14 @@ function UpdatePassword(password) {
 function update(msg, model) {
   switch (msg.tag) {
     case "UpdateEmail":
-      return {
-        model: assoc("email", msg.email, model),
-        effect: Effect.empty()
-      };
+      return [assoc("email", msg.email, model), Effect.empty()];
 
     case "UpdatePassword":
       console.log("UpdatePassword");
-      return {
-        model: assoc("password", msg.password, model),
-        effect: Effect.empty()
-      };
+      return [assoc("password", msg.password, model), Effect.empty()];
 
     default:
-      return { model, effect: Effect.empty() };
+      return [model, Effect.empty()];
   }
 }
 

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -1,10 +1,7 @@
 import { Msg } from "./msg";
 import { Maybe, Just } from "./maybe";
 
-interface ModelWithEffect<M> {
-  model: M;
-  effect: Effect;
-}
+type ModelWithEffect<M> = [M, Effect];
 
 type Effect = _Effect;
 

--- a/src/program.tsx
+++ b/src/program.tsx
@@ -21,7 +21,7 @@ class Program extends React.Component<ProgramProps, ProgramState> {
   constructor(props: ProgramProps) {
     super(props);
     const { init, subscriptions } = props;
-    const { model, effect } = init();
+    const [model, effect] = init();
     this.state = { model };
     this._updater = this._updater.bind(this);
     this._isMounted = false;
@@ -49,7 +49,7 @@ class Program extends React.Component<ProgramProps, ProgramState> {
     console.log("[Gongfu] Running Update for ", msg.tag);
 
     const { update } = this.props;
-    const { model, effect } = update(msg, this.state.model);
+    const [model, effect] = update(msg, this.state.model);
 
     if (this._isMounted) {
       console.log("[Gongfu] Setting state");


### PR DESCRIPTION
This removes a little syntax boilerplate and allowing you to simply
return an array with 2 values; model and effect.

Typescript makes this easy to type-check.

Slowly chipping away at some API improvements.