### PR TITLE
Cache updaters to reduce GC from rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc; browserify examples/LoginForm/Main.js -o examples/LoginForm/public/bundle.js -t [ babelify --presets [ es2015 react ] ]",
+    "pretest": "rm -rf dist; tsc --outDir dist/ --module commonjs",
     "test": "mocha",
     "prepublishOnly": "rm -rf dist; tsc --outDir dist/ --module commonjs"
   },

--- a/src/updater_for.ts
+++ b/src/updater_for.ts
@@ -1,9 +1,28 @@
 import { Msg, MsgConstructor } from "./msg";
 
 type Updater = (msg: Msg) => void;
+type UpdaterCache = Map<MsgConstructor, Map<Updater, Updater>>;
+
+// Not using WeakMap because updaters and MsgConstructors are const globals
+const updaterCache: UpdaterCache = new Map();
+
+function getUpdaterMap(msg: MsgConstructor): Map<Updater, Updater> {
+  let updaterMap = updaterCache.get(msg);
+
+  if (updaterMap == null) {
+    updaterCache.set(msg, updaterMap = new Map());
+  }
+  return updaterMap;
+}
 
 function updaterFor(updater: Updater, Msg: MsgConstructor): Updater {
-  return (msgData: any) => updater(Msg(msgData));
+  const updaterMap = getUpdaterMap(Msg);
+  let cachedUpdater = updaterMap.get(updater);
+
+  if (cachedUpdater == null) {
+    updaterMap.set(updater, cachedUpdater = (childMsg) => updater(Msg(childMsg)));
+  }
+  return cachedUpdater;
 }
 
 export default updaterFor;

--- a/test/updater_for_test.js
+++ b/test/updater_for_test.js
@@ -1,0 +1,39 @@
+import expect from "expect.js";
+import updaterFor from "../dist/updater_for";
+
+function Message1() {
+  return { tag: "Message1" };
+}
+
+function Message2() {
+  return { tag: "Message2" };
+}
+
+function ParentMessage(msg) {
+  return { tag: "ParentMessage", msg };
+}
+
+function update(msg, model) {
+  return { update: msg };
+}
+
+describe("updaterFor", () => {
+  it("returns an updater that wraps child messages", () => {
+    const updater = updaterFor(update, ParentMessage);
+
+    expect(typeof updater).to.be("function");
+
+    let result = updater(Message1());
+    expect(result).to.eql({ update: { tag: "ParentMessage", msg: { tag: "Message1" } } });
+
+    result = updater(Message2());
+    expect(result).to.eql({ update: { tag: "ParentMessage", msg: { tag: "Message2" } } });
+  });
+
+  it("caches the updater functions", () => {
+    const updater1 = updaterFor(update, ParentMessage);
+    const updater2 = updaterFor(update, ParentMessage);
+
+    expect(updater2).to.be(updater1);
+  });
+});


### PR DESCRIPTION
In the rendering pipeline, `updaterFor` is called frequently to enable messages to flow from parent to child components. The current implementation returns a new function instance every time. While this is fast, it has a couple shortcomings:
1. The new function instance means that Gongfu components cannot be `PureComponents` because the `updater` prop will always change.
2. The additional function instances add overhead for the garbage collector.

Since this is a pure function, we can use a cache that returns a single function instance for every pair of `updater` and `Msg`.