### PR TITLE
Run effects in the next event loop

### DIFF
--- a/src/effect.ts
+++ b/src/effect.ts
@@ -58,9 +58,13 @@ class _Effect {
 // Needs to be _AFTER_ the implementation of _Effect
 const EMPTY_EFFECT = Effect();
 
+function isEmpty(effect: Effect) {
+  return effect === EMPTY_EFFECT;
+}
+
 namespace Effect {
   export var of = _Effect.of;
   export var empty = _Effect.empty;
 }
 
-export { ModelWithEffect, Effect, EMPTY_EFFECT };
+export { ModelWithEffect, Effect, isEmpty };

--- a/src/program.tsx
+++ b/src/program.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import * as React from "react";
 import Sub from "./sub";
 import { Msg, msgToString } from "./msg";
-import { Effect, ModelWithEffect } from "./effect";
+import { Effect, ModelWithEffect, isEmpty } from "./effect";
 
 interface ProgramProps {
   Component: any;
@@ -69,10 +69,11 @@ class Program extends React.Component<ProgramProps, ProgramState> {
   }
 
   _runEffect(effect: Effect): void {
-    if (this.props.debugEnabled && effect !== Effect.empty()) {
-      console.log("[Gongfu] Running Effect");
-    }
-    effect.run(this._updater);
+    if (isEmpty(effect)) return;
+    if (this.props.debugEnabled) console.log("[Gongfu] Running Effect");
+
+    // Run the effect in the next frame (60fps) so React can update the UI in the current event loop
+    setTimeout(effect.run.bind(effect, this._updater), 16);
   }
 
   render(): React.ReactElement<any> {

--- a/test/effect_test.js
+++ b/test/effect_test.js
@@ -1,8 +1,14 @@
 import expect from "expect.js";
+import { Effect, isEmpty } from "../dist/effect";
 
 describe("Effect", () => {
-  it("works", () => {
-    // TODO
-    expect(1).to.be(1);
-  });
+  describe("isEmpty", () => {
+    it("returns true for the empty effect", () => {
+      expect(isEmpty(Effect.empty())).to.be(true);
+    });
+    it("returns false for standard effects", () => {
+      expect(isEmpty(Effect())).to.be(false);
+      expect(isEmpty(Effect(_ => {}))).to.be(false);
+    });
+  })
 });


### PR DESCRIPTION
Gongfu currently runs effects synchronously after React `setState` has finished. This can cause "stalls" because effects might run other updaters, which cause further state changes. For example:

- updater(msg) returns model + effect
- setState()
- runEffect()
- Effect calls updater(msg2)
- Gongfu runs updater
- setState()
- React updates state a second time

Effects can be run asynchronously because their very nature implies a change that happens outside the processing of updates.
Gongfu schedules the effect to run in the next frame (assuming 60fps) using `setTimeout`.