### PR TITLE
Proposal: Subscriptions for View components

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,8 @@ Gongfu
 Gongfu provides state management for React similar to The Elm Architecture and
 Redux. It has composable `update` functions and `Effects` build-in.
 
+## Overview
+See [docs/overview.md](docs/overview.md)
+
 ## Example
 See a full example in the examples folder

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,6 @@
 # Gongfu Overview
 
-How changes are propagated
+How changes are propagated:
 
 ```
                       ╭──────────────┆────╮
@@ -38,4 +38,34 @@ How changes are propagated
         ║ └─────────────────────┘ ║  ┆        │
         ╚═════════════●═══════════╝  ┆        │
                       ╰──────────────┆────────╯
+```
+
+## Subscriptions
+
+Subscriptions allow a component to propagate external events as updates. In React terms, subscriptions are typically active
+while the component is mounted. However it is possible to have subscriptions survive the component's lifetime.
+
+This example shows how to implement the `subscriptions` function and bind it to the (View) component.
+```
+
+function subscriptions(model) {
+      // This is called with the component's model state when it is being mounted
+      return Sub((updater, onCleanup) => {
+            const listener = SomeModule.addEventListener("locationChange", loc => updater(LocationChanged(loc)));
+            // Pass a function to invoke when the component is unmounted so we can cleanup the listener
+            onCleanup(() => {
+                  SomeModule.removeEventListener("locationChange", listener);
+            })
+            // If you do not need to cleanup subscriptions, then `onCleanup` can be omitted.
+      });
+}
+
+function MyComponent(props) {
+      return <View>...</View>;
+}
+
+const Component = withSubscriptions(MyComponent, subscriptions);
+
+export { Component, Model, init, update };
+
 ```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -50,13 +50,13 @@ This example shows how to implement the `subscriptions` function and bind it to 
 
 function subscriptions(model) {
       // This is called with the component's model state when it is being mounted
-      return Sub((updater, onCleanup) => {
+      return Sub((updater) => {
             const listener = SomeModule.addEventListener("locationChange", loc => updater(LocationChanged(loc)));
-            // Pass a function to invoke when the component is unmounted so we can cleanup the listener
-            onCleanup(() => {
+            // Return a function to invoke when the component is unmounted so we can cleanup the listener
+            return function cleanup() {
                   SomeModule.removeEventListener("locationChange", listener);
-            })
-            // If you do not need to cleanup subscriptions, then `onCleanup` can be omitted.
+            });
+            // If you do not need to cleanup subscriptions, then a return value can be omitted.
       });
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,8 @@ export interface Msg {
 export type MsgConstructor = (...args: any[]) => Msg;
 export type Updater = (msg: Msg) => void;
 export type Runner = (updater: Updater) => void;
-export type Setup = (onChange: Updater) => void;
+export type Cleanup = () => void;
+export type Setup = (onChange: Updater) => Cleanup | undefined;
 
 export interface Effect {
   concat(that: Effect): Effect;
@@ -35,7 +36,7 @@ export interface ModelWithEffect<M> {
 }
 
 export interface Sub {
-  run(updater: Updater): void;
+  run(updater: Updater): Cleanup | undefined;
 }
 
 export function Sub(setup?: Setup): Sub;
@@ -44,6 +45,10 @@ export namespace Sub {
   function of(setup?: Setup): Sub;
   function none(): Sub;
 }
+
+export function withSubscriptions<Props>(
+  UserComponent: React.ComponentType<Props>,
+  subscriptions: (model: any) => Sub): React.ComponentType<Props>;
 
 export function updaterFor<M extends Msg>(updater: (msg: M) => void, Msg: MsgConstructor): Updater;
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": ">=15.0.0"
   },
   "devDependencies": {
-    "@types/react": "^16.0.5",
+    "@types/react": "^16.9.0",
     "babel-cli": "^6.24.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
@@ -28,7 +28,8 @@
     "ramda": "^0.23.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "typescript": "^2.5.2"
+    "react-test-renderer": "15.6.1",
+    "typescript": "^2.9.2"
   },
   "dependencies": {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Effect, ModelWithEffect } from "./effect";
 import updaterFor from "./updater_for";
 import Sub from "./sub";
 import { Msg, MsgConstructor } from "./msg";
+import withSubscriptions from "./with_subs";
 
 export {
   Msg,
@@ -11,5 +12,6 @@ export {
   Effect,
   ModelWithEffect,
   updaterFor,
-  Sub
+  Sub,
+  withSubscriptions,
 };

--- a/src/sub.ts
+++ b/src/sub.ts
@@ -4,7 +4,7 @@ type Sub = _Sub;
 
 type Updater = (msg: Msg) => void;
 type Cleanup = () => void;
-type Setup = (onChange: Updater, onCleanup?: Cleanup) => void;
+type Setup = (onChange: Updater) => Cleanup | undefined;
 
 function Sub(setup?: Setup): Sub {
   return new _Sub(setup);
@@ -25,9 +25,9 @@ class _Sub {
     this.setup = setup;
   }
 
-  run(updater: Updater, onCleanup?: Cleanup) {
+  run(updater: Updater): Cleanup | undefined {
     if (typeof this.setup === "function") {
-      this.setup(updater, onCleanup);
+      return this.setup(updater);
     }
   }
 }

--- a/src/sub.ts
+++ b/src/sub.ts
@@ -1,10 +1,10 @@
-import { pipe } from "ramda";
 import { Msg } from "./msg";
 
 type Sub = _Sub;
 
 type Updater = (msg: Msg) => void;
-type Setup = (onChange: Updater) => void;
+type Cleanup = () => void;
+type Setup = (onChange: Updater, onCleanup?: Cleanup) => void;
 
 function Sub(setup?: Setup): Sub {
   return new _Sub(setup);
@@ -25,9 +25,9 @@ class _Sub {
     this.setup = setup;
   }
 
-  run(updater: Updater) {
+  run(updater: Updater, onCleanup?: Cleanup) {
     if (typeof this.setup === "function") {
-      this.setup(updater);
+      this.setup(updater, onCleanup);
     }
   }
 }

--- a/src/with_subs.ts
+++ b/src/with_subs.ts
@@ -1,0 +1,42 @@
+import React from "react";
+import { Msg } from "./msg";
+import Sub from "./sub";
+
+type Cleanup = () => void;
+
+interface IHaveModel {
+  model: {};
+  updater: (m: Msg) => void;
+}
+
+function withSubscriptions<Props extends IHaveModel>(
+  UserComponent: React.ComponentType<Props>,
+  subscriptions: (model: {}) => Sub
+): React.ComponentClass<Props> {
+
+  return class GongfuWithSubs extends React.Component<Props> {
+    cleanup?: Cleanup;
+
+    componentDidMount() {
+      const sub = subscriptions(this.props.model);
+      sub.run(this.props.updater, this.onCleanup.bind(this));
+    }
+
+    componentWillUnmount() {
+      if (this.cleanup) {
+        this.cleanup();
+        delete this.cleanup;
+      }
+    }
+
+    onCleanup(cleanup: Cleanup) {
+      this.cleanup = cleanup;
+    }
+
+    render() {
+      return React.createElement(UserComponent as any, this.props);
+    }
+  };
+}
+
+export default withSubscriptions;

--- a/src/with_subs.ts
+++ b/src/with_subs.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Msg } from "./msg";
 import Sub from "./sub";
 
@@ -12,14 +12,13 @@ interface IHaveModel {
 function withSubscriptions<Props extends IHaveModel>(
   UserComponent: React.ComponentType<Props>,
   subscriptions: (model: {}) => Sub
-): React.ComponentClass<Props> {
-
-  return class GongfuWithSubs extends React.Component<Props> {
+): React.ComponentType<Props> {
+  return class WithSubscriptions extends React.Component<Props> {
     cleanup?: Cleanup;
 
     componentDidMount() {
       const sub = subscriptions(this.props.model);
-      sub.run(this.props.updater, this.onCleanup.bind(this));
+      this.cleanup = sub.run(this.props.updater);
     }
 
     componentWillUnmount() {
@@ -29,12 +28,8 @@ function withSubscriptions<Props extends IHaveModel>(
       }
     }
 
-    onCleanup(cleanup: Cleanup) {
-      this.cleanup = cleanup;
-    }
-
     render() {
-      return React.createElement(UserComponent as any, this.props);
+      return React.createElement(UserComponent, this.props);
     }
   };
 }

--- a/test/with_subs_test.js
+++ b/test/with_subs_test.js
@@ -1,0 +1,47 @@
+import expect from "expect.js";
+import React from "react";
+import TestRenderer from "react-test-renderer";
+import Sub from "../dist/sub";
+import withSubscriptions from "../dist/with_subs";
+
+function MyComponent(props) {
+  return React.createElement("span", {}, "Hello World");
+}
+
+describe("withSubscriptions", () => {
+  let subscriptionsCalled = false;
+  let stopSubscriptionsCalled = false;
+  const model = {};
+
+  function subscriptions(m) {
+    return Sub(_ => {
+      subscriptionsCalled = m === model;
+      return function stop() {
+        stopSubscriptionsCalled = true;
+      }
+    })
+  }
+
+  beforeEach(() => {
+    subscriptionsCalled = false;
+    stopSubscriptionsCalled = false;
+  })
+
+  it("calls subscriptions function in componentDidMount", () => {
+    const Component = withSubscriptions(MyComponent, subscriptions);
+    TestRenderer.create(React.createElement(Component, { model }));
+
+    expect(subscriptionsCalled).to.be(true);
+    expect(stopSubscriptionsCalled).to.be(false);
+  });
+
+  it("calls the function returned in componentWillUnmount", () => {
+    const Component = withSubscriptions(MyComponent, subscriptions);
+    const testRenderer = TestRenderer.create(React.createElement(Component, { model }));
+
+    expect(subscriptionsCalled).to.be(true);
+
+    testRenderer.unmount();
+    expect(stopSubscriptionsCalled).to.be(true);
+  })
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,18 @@
 # yarn lockfile v1
 
 
-"@types/react@^16.0.5":
-  version "16.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.5.tgz#d713cf67cc211dea20463d2a0b66005c22070c4b"
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^16.9.0":
+  version "16.9.16"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.16.tgz#4f12515707148b1f53a8eaa4341dae5dfefb066d"
+  integrity sha512-dQ3wlehuBbYlfvRXfF5G+5TbZF3xqgkikK7DWAsQXe2KnzV+kjD4W2ea+ThCrKASZn9h98bjjPzoTYzfRqyBkw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 JSONStream@^1.0.3:
   version "1.3.1"
@@ -998,6 +1007,11 @@ crypto-browserify@^3.0.0:
     pbkdf2 "^3.0.3"
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
+
+csstype@^2.2.0:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
+  integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -2040,6 +2054,14 @@ react-dom@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
+react-test-renderer@15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
+  integrity sha1-Am9KW7VVJmH9LMS7zQ1LyKNev34=
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
+
 react@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
@@ -2433,9 +2455,10 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
+typescript@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+  integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
 
 ua-parser-js@^0.7.9:
   version "0.7.14"


### PR DESCRIPTION
I think it would be cool if we can use subscriptions beyond just the root (App) component.
This is a proposal for a mechanism to allow an individual component to have subscriptions that are scoped to the component's mounted lifetime. 

The API is a small extension of `Sub` to support an optional cleanup function that is called when the component is unmounted, and a new "recompose-like" HOC to hook the `subscriptions` function to the component lifecycle.

What do you think?