### PR TITLE
Add an API to send messages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,3 +60,17 @@ export interface ProgramState {
 }
 
 export class Program extends Component<ProgramProps, ProgramState> {}
+
+/**
+ * Returns an effect which sends a message for the next frame.
+ * "Next frame" means a 16ms delay, assuming 60fps for rendering.
+ * @param msg The message to send
+ */
+export function sendMessage(msg: Msg): Effect;
+
+/**
+ * * Returns an effect which sends a message after a delay.
+ * @param msg The message to send
+ * @param delay The time in milliseconds before the message is sent
+ */
+export function sendMessageDelayed(msg: Msg, delay: number): Effect;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Effect, ModelWithEffect } from "./effect";
 import updaterFor from "./updater_for";
 import Sub from "./sub";
 import { Msg, MsgConstructor } from "./msg";
+import { sendMessage, sendMessageDelayed} from "./send_message";
 
 export {
   Msg,
@@ -10,6 +11,8 @@ export {
   Program,
   Effect,
   ModelWithEffect,
+  Sub,
   updaterFor,
-  Sub
+  sendMessage,
+  sendMessageDelayed,
 };

--- a/src/send_message.ts
+++ b/src/send_message.ts
@@ -1,0 +1,12 @@
+import { Effect } from "./effect";
+import { Msg } from "./msg";
+
+function sendMessage(msg: Msg): Effect {
+  return Effect(updater => setTimeout(updater, 16, msg));
+}
+
+function sendMessageDelayed(msg: Msg, delay: number): Effect {
+  return Effect(updater => setTimeout(updater, delay, msg));
+}
+
+export { sendMessage, sendMessageDelayed };

--- a/test/send_message_test.js
+++ b/test/send_message_test.js
@@ -1,0 +1,30 @@
+import expect from "expect.js";
+import { sendMessage, sendMessageDelayed } from "../dist/send_message";
+
+function Message1() {
+  return { tag: "Message1" };
+}
+
+function Message2() {
+  return { tag: "Message2" };
+}
+
+describe("sendMessage", () => {
+  it("returns an effect which calls the updater with the message", done => {
+    const effect = sendMessage(Message1());
+    effect.run(msg => {
+      expect(msg.tag).to.be("Message1");
+      done();
+    })
+  });
+
+  it("returns an effect which calls the updater after a delay", done => {
+    const sentAt = Date.now();
+    const effect = sendMessageDelayed(Message2(), 300);
+    effect.run(msg => {
+      expect(msg.tag).to.be("Message2");
+      expect(Date.now() >= sentAt + 300).to.be(true);
+      done();
+    })
+  });
+});


### PR DESCRIPTION
I thought it would be useful to have a high-level API for sending messages via Effects.
It helps to make it clear in the code that an update needs to send another message.

It also avoids a potential bug where an update that sends two messages, via Effects, will lose the model updates from all but the last effect. For example:

```
function update(msg: Msg, model: Model) {
  case "MyMessage":
    const effect1 = Effect(updater => updater(Message2(...)));
    const effect2 = Effect(updater => updater(Message3(...)));
    return { model, effect: effect1.concat(effect2) };
  case "Message2":
    // return updated model
  case "Message3":
    // return updated model
}
```
In the above example, the model changes from `Message2` will be lost because the two updates are run synchronously. And the update for Message3 will not have the model returned by Message2, but the original model at the time the effect was created.

By using a timeout, the messages will be run in sequence and have up-to-date state.