### PR TITLE
Provide subscriptions with latest props

### DIFF
--- a/src/with_subs.ts
+++ b/src/with_subs.ts
@@ -11,13 +11,13 @@ interface IHaveModel {
 
 function withSubscriptions<Props extends IHaveModel>(
   UserComponent: React.ComponentType<Props>,
-  subscriptions: (model: {}) => Sub
+  subscriptions: (model: {}, props: () => Props) => Sub
 ): React.ComponentType<Props> {
   return class WithSubscriptions extends React.Component<Props> {
     cleanup?: Cleanup;
 
     componentDidMount() {
-      const sub = subscriptions(this.props.model);
+      const sub = subscriptions(this.props.model, () => this.props);
       this.cleanup = sub.run(this.props.updater);
     }
 


### PR DESCRIPTION
Sometimes an event handler needs access to the latest props to pass in messages to an update. For example:
```
function subscriptions(model) {
  return Sub(updater => {
    something.addEventListener("click", e => {
      updater(SomethingHappened(props.objectId, e.value));
    });
  });
}
```
There is no way for the event handler to pass props in the message. We can resolve this by giving subscriptions functions an additional argument that provides the current props at the time the subscription is invoked.
```
function subscriptions(model, getProps) {
  return Sub(updater => {
    something.addEventListener("click", e => {
      updater(SomethingHappened(getProps().objectId, e.value));
    });
  });
}
```
Subscriptions that don't need access to props can omit the second argument.
